### PR TITLE
fix: Add semantic release configuration for automatic versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,46 @@ jobs:
   build:
     name: Build Package
     runs-on: ubuntu-latest
-    needs: [test]  # Only wait for tests, run parallel with lint/type-check
+    if: github.event_name != 'push' || github.ref != 'refs/heads/main'
+    needs: [test]  # Only for PRs and non-main branches
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: "**/pyproject.toml"
+
+      - name: Install dependencies
+        run: |
+          uv sync --extra dev
+
+      - name: Build package
+        run: |
+          uv build
+
+      - name: Check package
+        run: |
+          uv pip install twine
+          uv run twine check dist/*
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  build-after-release:
+    name: Build Package (After Release)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [release]  # For main branch, wait for version bump
     steps:
       - uses: actions/checkout@v4
 
@@ -195,7 +234,7 @@ jobs:
     runs-on: ubuntu-latest
     # Only publish on push to main, not on PRs
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [release, build]  # Release already depends on all tests
+    needs: [build-after-release]  # Use the build that happens after version bump
     # Requires setting up Trusted Publishing on PyPI:
     # 1. Go to https://pypi.org/manage/project/celeste-ai/settings/publishing/
     # 2. Add GitHub publisher with: owner=celeste-kai, repo=celeste-ai, workflow=ci.yml, environment=pypi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,26 @@ jobs:
           name: codecov-umbrella
           fail_ci_if_error: false
 
+  release:
+    name: Semantic Release
+    runs-on: ubuntu-latest
+    # Only run on main branch after tests pass
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [lint, type-check, security, test]
+    permissions:
+      contents: write  # To push version bump commit
+      id-token: write  # For PyPI trusted publishing
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Need full history for semantic release
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Python Semantic Release
+        uses: python-semantic-release/python-semantic-release@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
   build:
     name: Build Package
     runs-on: ubuntu-latest
@@ -175,7 +195,7 @@ jobs:
     runs-on: ubuntu-latest
     # Only publish on push to main, not on PRs
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [lint, type-check, security, test, build]
+    needs: [release, build]  # Release already depends on all tests
     # Requires setting up Trusted Publishing on PyPI:
     # 1. Go to https://pypi.org/manage/project/celeste-ai/settings/publishing/
     # 2. Add GitHub publisher with: owner=celeste-kai, repo=celeste-ai, workflow=ci.yml, environment=pypi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing
+
+## Setup
+```bash
+uv sync --extra dev
+pre-commit install
+```
+
+## Commit Convention
+
+We use [Conventional Commits](https://www.conventionalcommits.org/) for automatic versioning:
+
+- `fix:` → Patch (0.0.1 → 0.0.2)
+- `feat:` → Minor (0.0.2 → 0.1.0)
+- `BREAKING CHANGE:` or `!` → Major (0.1.0 → 1.0.0)
+- `docs:`, `style:`, `refactor:`, `test:`, `chore:` → No version bump
+
+Examples:
+```bash
+fix: handle empty API keys
+feat: add Claude 3.5 support
+feat!: migrate to pydantic v2
+```
+
+## Workflow
+1. Branch from `main`
+2. Make changes (follow commit convention)
+3. Run `make cicd`
+4. Create PR
+5. After merge, version bumps automatically

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Celeste AI Framework
 
+[![semantic-release: conventionalcommits](https://img.shields.io/badge/semantic--release-conventionalcommits-e10079?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
+[![PyPI version](https://badge.fury.io/py/celeste-ai.svg)](https://pypi.org/project/celeste-ai/)
+
 > **Note: This is a placeholder package to reserve the name. The full framework is coming soon!**
 
 Celeste AI will be a unified multi-modal AI framework providing a single interface for:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,3 +126,16 @@ skips = ["*/test_*.py", "*_test.py"]
 
 # Note: dev dependencies are in [project.optional-dependencies]
 # This section can be removed as it's non-standard
+
+[tool.semantic_release]
+version_toml = ["pyproject.toml:project.version"]
+branch = "main"
+upload_to_pypi = false  # We handle this separately in CI
+upload_to_release = true
+build_command = "uv build"
+commit_message = "chore(release): {version} [skip ci]"
+
+[dependency-groups]
+dev = [
+    "python-semantic-release>=10.4.1",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,8 @@ upload_to_release = true
 build_command = "uv build"
 commit_message = "chore(release): {version} [skip ci]"
 
+# Using PEP 735 dependency groups (supported by uv)
+# For older tools, these would go in [project.optional-dependencies]
 [dependency-groups]
 dev = [
     "python-semantic-release>=10.4.1",


### PR DESCRIPTION
## Summary
- Add python-semantic-release configuration to automate version bumping
- Version will automatically increment based on commit messages
- This PR uses `fix:` prefix, so it will bump version from 0.0.1 to 0.0.2

## How it works
- `fix:` commits → patch bump (0.0.1 → 0.0.2)
- `feat:` commits → minor bump (0.0.2 → 0.1.0)
- `BREAKING CHANGE:` → major bump (0.1.0 → 1.0.0)

## Test plan
- [x] Semantic release config added to pyproject.toml
- [x] Release job added to CI workflow
- [x] Publish job updated to depend on release
- [ ] On merge, version should bump from 0.0.1 to 0.0.2