### PR TITLE
fix: Install uv properly in semantic release build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,12 @@ version_toml = ["pyproject.toml:project.version"]
 branch = "main"
 upload_to_pypi = false  # We handle this separately in CI
 upload_to_release = true
-build_command = "uv build"
+build_command = """
+curl -LsSf https://astral.sh/uv/install.sh | sh && \
+source /root/.local/bin/env && \
+uv sync && \
+uv build
+"""
 commit_message = "chore(release): {version} [skip ci]"
 
 # Using PEP 735 dependency groups (supported by uv)


### PR DESCRIPTION
## Summary
Fixes the semantic release build failure by properly installing uv in the Docker container.

## Problem
Semantic release was failing with 'uv: command not found' because:
- The Docker container doesn't have uv pre-installed
- We need to create a virtual environment before building

## Solution
- Install uv using the official installer script
- Source the env file to set PATH correctly
- Run `uv sync` to create venv and install dependencies
- Then build with `uv build`

## Test plan
- [x] Build command properly chains all steps
- [ ] Semantic release will run successfully after merge
- [ ] Version will bump from 0.0.1 to 0.0.2