### PR TITLE
fix: Use export PATH instead of source env for uv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ upload_to_pypi = false  # We handle this separately in CI
 upload_to_release = true
 build_command = """
 curl -LsSf https://astral.sh/uv/install.sh | sh && \
-source /root/.local/bin/env && \
+export PATH="/root/.local/bin:$PATH" && \
 uv sync && \
 uv build
 """


### PR DESCRIPTION
## Summary
Fixes the semantic release build failure by using standard PATH export.

## Problem
The build was failing because `source /root/.local/bin/env` file doesn't exist after uv installation.

## Solution  
Use standard `export PATH="/root/.local/bin:$PATH"` to make uv available in the shell.

## Test plan
- [ ] Semantic release will find uv command after installation
- [ ] Build will complete successfully
- [ ] Version will bump to 0.0.2