### PR TITLE
fix: use HOME variable for uv installation path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ upload_to_pypi = false  # We handle this separately in CI
 upload_to_release = true
 build_command = """
 curl -LsSf https://astral.sh/uv/install.sh | sh && \
-export PATH="/root/.local/bin:$PATH" && \
+export PATH="$HOME/.local/bin:$PATH" && \
 uv sync && \
 uv build
 """


### PR DESCRIPTION
## Summary
- Fixed PATH export to use $HOME/.local/bin instead of hardcoded /root/.local/bin
- The uv installer uses $HOME which resolves to /github/home in GitHub Actions, not /root
- This was causing 'uv: command not found' errors during semantic-release build

## Impact
This fix should allow semantic-release to properly build the package and bump the version from 0.0.1 to 0.0.2.

The installer output showed:
```
installing to: /github/home/.local/bin
```

But we were exporting PATH with /root/.local/bin, causing the mismatch.