### PR TITLE
chore: remove semantic-release and revert to manual versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,69 +133,10 @@ jobs:
           name: codecov-umbrella
           fail_ci_if_error: false
 
-  release:
-    name: Semantic Release
-    runs-on: ubuntu-latest
-    # Only run on main branch after tests pass
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [lint, type-check, security, test]
-    permissions:
-      contents: write  # To push version bump commit
-      id-token: write  # For PyPI trusted publishing
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Need full history for semantic release
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Python Semantic Release
-        uses: python-semantic-release/python-semantic-release@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
   build:
     name: Build Package
     runs-on: ubuntu-latest
-    if: github.event_name != 'push' || github.ref != 'refs/heads/main'
-    needs: [test]  # Only for PRs and non-main branches
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v3
-        with:
-          enable-cache: true
-          cache-dependency-glob: "**/pyproject.toml"
-
-      - name: Install dependencies
-        run: |
-          uv sync --extra dev
-
-      - name: Build package
-        run: |
-          uv build
-
-      - name: Check package
-        run: |
-          uv pip install twine
-          uv run twine check dist/*
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: dist/
-
-  build-after-release:
-    name: Build Package (After Release)
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [release]  # For main branch, wait for version bump
+    needs: [test]
     steps:
       - uses: actions/checkout@v4
 
@@ -234,7 +175,7 @@ jobs:
     runs-on: ubuntu-latest
     # Only publish on push to main, not on PRs
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [build-after-release]  # Use the build that happens after version bump
+    needs: [build]  # Use the build artifacts
     # Requires setting up Trusted Publishing on PyPI:
     # 1. Go to https://pypi.org/manage/project/celeste-ai/settings/publishing/
     # 2. Add GitHub publisher with: owner=celeste-kai, repo=celeste-ai, workflow=ci.yml, environment=pypi

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -17,14 +17,14 @@ jobs:
     #   github.event.pull_request.user.login == 'external-contributor' ||
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
+
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
       issues: read
       id-token: write
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -43,12 +43,11 @@ jobs:
             - Performance considerations
             - Security concerns
             - Test coverage
-            
+
             Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
 
             Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
-          
+
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          
+
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
@@ -47,4 +47,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
           # claude_args: '--model claude-opus-4-1-20250805 --allowed-tools Bash(gh pr:*)'
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-ai"
-version = "1.0.0"
+version = "0.0.2"
 description = "Celeste AI Framework - Multi-modal AI interface (placeholder)"
 authors = [{name = "agent-kai", email = "kai@celeste-ai.co"}]
 readme = "README.md"
@@ -117,32 +117,7 @@ disallow_incomplete_defs = false
 
 [tool.bandit]
 exclude_dirs = [".venv", "__pycache__"]
-# Skip B101 (assert_used) since we use pytest
-skips = ["B101"]
+skips = ["B101"] # Skip B101 (assert_used) since we use pytest
 
 [tool.bandit.assert_used]
-# Allow assertions in test files
-skips = ["*/test_*.py", "*_test.py"]
-
-# Note: dev dependencies are in [project.optional-dependencies]
-# This section can be removed as it's non-standard
-
-[tool.semantic_release]
-version_toml = ["pyproject.toml:project.version"]
-branch = "main"
-upload_to_pypi = false  # We handle this separately in CI
-upload_to_release = true
-build_command = """
-curl -LsSf https://astral.sh/uv/install.sh | sh && \
-export PATH="$HOME/.local/bin:$PATH" && \
-uv sync && \
-uv build
-"""
-commit_message = "chore(release): {version} [skip ci]"
-
-# Using PEP 735 dependency groups (supported by uv)
-# For older tools, these would go in [project.optional-dependencies]
-[dependency-groups]
-dev = [
-    "python-semantic-release>=10.4.1",
-]
+skips = ["*/test_*.py", "*_test.py"] # Allow assertions in test files


### PR DESCRIPTION
## Summary
- Removed automatic semantic-release versioning (was overengineered)
- Simplified CI workflow for manual version management
- Updated version to 0.0.2

## Changes
- ✅ Removed `[tool.semantic_release]` configuration from pyproject.toml
- ✅ Removed `python-semantic-release` dependency
- ✅ Simplified CI by removing `release` and `build-after-release` jobs
- ✅ Version set to 0.0.2 (down from auto-bumped 1.0.0)
- ✅ Cleaned up obsolete comments

## New workflow
1. Manually update version in `pyproject.toml`
2. Push to main branch
3. CI automatically builds and publishes to PyPI

Much simpler and more predictable!