### PR TITLE
chore: add pytest with coverage to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,3 +55,13 @@ repos:
         name: "📓 Clean Jupyter notebook outputs"
         description: "Strip output from Jupyter notebooks"
         args: [--max-size=5]
+
+  - repo: local
+    hooks:
+      - id: pytest
+        name: "🧪 Run tests with coverage"
+        entry: uv run pytest tests/ --cov=celeste --cov-report=term-missing --cov-fail-under=90
+        language: system
+        types: [python]
+        pass_filenames: false
+        always_run: true


### PR DESCRIPTION
## Summary
Adds pytest with coverage reporting to pre-commit hooks for early test failure detection.

## Details
- 🧪 Tests run automatically before each commit
- ⚡ Fast execution: ~1 second for 96 tests  
- 📊 Coverage reporting with `--verbose` flag
- ❌ Commits blocked if coverage drops below 90%
- ✅ Current coverage: **98.92%**

## Usage
- **Normal commit**: Shows pass/fail only
- **Verbose mode**: `pre-commit run --all-files --verbose` shows full coverage report
- **On failure**: Full output always shown

## Why this helps
- Catches test failures before they reach CI
- Prevents broken code from entering version control
- Maintains high coverage standards (90% minimum)